### PR TITLE
Update COVID-19 Guidance

### DIFF
--- a/src/components/Covid.js
+++ b/src/components/Covid.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { BACKGROUND_LIGHT_TEXT } from './Colors';
 import HorizontalRule from './HorizontalRule';
+import Link from './Link';
 
 const Youtube = styled.i`
   color: red;
@@ -13,36 +14,44 @@ export default function Covid() {
     <>
       <h3>COVID-19</h3>
       <p className="subtitle1">
-        We wish we didn&apos;t have to have this conversation but we want to ensure the safety of
-        our friends and family as we celebrate together.
+        We wish we didn&apos;t have to have this conversation; however, we want to ensure the
+        safety of our friends and family as we celebrate together.
       </p>
       <HorizontalRule color={BACKGROUND_LIGHT_TEXT} />
       <h4>Vaccination Requirement</h4>
       <p className="body1">
-        We are requiring that all guests be fully vaccinated prior to the events.
-        This choice is not intended to be about politics, personal, or religious beliefs, or
-        individual liberties. We know many of you are flying, and we want to ensure that we
-        are considerate and mindful of everyone&apos;s health, safety, and level of comfort.
-        We do fully understand that the decision to be vaccinated is a personal choice and
-        that not everyone ascribes to receiving a Covid-19 vaccine. It is our wish to err on
-        the side of caution, doing everything in our power to provide the most safe venue for
-        us and all of our guests to feel comfortable while attending. If you are unable or
-        unwilling to be vaccinated prior to attending we will certainly miss having you there
-        and will look forward to celebrating with you another time.
+        Previously we had required that all guests be fully vaccinated before the events.
+        After careful consideration, we have decided to rescind this requirement.
+        However, we ask that everyone tests before traveling, before the events,
+        and upon returning home. We ask that you not attend any of our events if you test
+        positive for COVID-19. If you test positive after our event, we ask that you call your
+        doctor immediately to discuss
+        {' '}
+        <Link
+          href="https://www.cdc.gov/coronavirus/2019-ncov/your-health/treatments-for-severe-illness.html"
+          text="treatment options"
+        />
+        . We wish to err on the side of caution,
+        doing everything in our power to provide the safest venue and for all our guests to feel
+        comfortable while attending.
       </p>
       <h4>Masks</h4>
       <p className="body1">
-        We plan to comply with local regulations regarding masks, gathering size, and social
-        distancing. If any local regulations impact our ability to celebrate in a safe
-        manner, we will communicate any updates as soon as we can.
+        If you are not fully vaccinated, we ask that you wear masks at all indoor locations.
+        We ask that everyone follows the
+        {' '}
+        <Link
+          href="https://www.cdc.gov/coronavirus/2019-ncov/travelers/masks-public-transportation.html"
+          text="CDC's guidance"
+        />
+        {' for wearing masks while traveling. '}
       </p>
       <h4>
         <Youtube className="fa-brands fa-youtube" />
         {' Live Stream'}
       </h4>
       <p className="body1">
-        We will provide a live stream of our ceremony for anyone that is unable to comply
-        with these measures.
+        We will provide a live stream of our ceremony for anyone unable to attend in person.
       </p>
     </>
   );

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 // TODO fix the hover color
-import { PRIMARY_CONTAINER_TEXT, SECONDARY } from '../Colors';
+import { PRIMARY_CONTAINER_TEXT, SECONDARY } from './Colors';
 
 const StyledLink = styled.a`
     color: ${PRIMARY_CONTAINER_TEXT};

--- a/src/components/Travel/Accommodations.js
+++ b/src/components/Travel/Accommodations.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Link from './Link';
+import Link from '../Link';
 
 export default function Accommodations() {
   return (

--- a/src/components/Travel/Activities.js
+++ b/src/components/Travel/Activities.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import Link from './Link';
+import Link from '../Link';
 
 const List = styled.ul`
     list-style-type: none;

--- a/src/components/Travel/Travel.js
+++ b/src/components/Travel/Travel.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Accommodations from './Accommodations';
 import Activities from './Activities';
 import HorizontalRule from '../HorizontalRule';
-import Link from './Link';
+import Link from '../Link';
 
 export default function Travel() {
   return (


### PR DESCRIPTION
Fixes #42 

# Changes
- Moves `Link` to the `components` folder so other pages can use it
- Updates the COVID-19 guidance

# Image

![image](https://user-images.githubusercontent.com/20402962/200964402-f47b7987-d893-4179-8936-b3e7c1a3302c.png)
